### PR TITLE
multiple random effects

### DIFF
--- a/R/glmmLasso_MultLambdas.r
+++ b/R/glmmLasso_MultLambdas.r
@@ -88,7 +88,9 @@ glmmLasso_MultLambdas <- function(fix, rnd, data,
     # builing the first Delta.start, transpose required to make dimension
     
     Delta.start <- first_fit$Deltamatrix[first_fit$conv.step, ] %>% t()
-    Q.start <- first_fit$Q_long[[first_fit$conv.step + 1]]
+    Q.start <- list()
+    Q.start[[1]] <- first_fit$Q_long[[first_fit$conv.step + 1]]
+    if(nrow(Q.start[[1]])==1) Q.start[[1]] <- c(Q.start[[1]])
     
     for (l in seq_along(lambdas))
     {
@@ -102,12 +104,12 @@ glmmLasso_MultLambdas <- function(fix, rnd, data,
                                     family = family,
                                     lambda = lambdas[l],
                                     control = list(start=Delta.start[l,],
-                                                   q_start=Q.start[l]),...)
+                                                   q_start=Q.start[[l]]),...)
         
         # storing model objects before storing to modList
         fit$lambda <- lambdas[l]
         fit$Delta.start <- Delta.start[l,]
-        fit$Q.start <- Q.start[l]
+        fit$Q.start <- Q.start[[l]]
         fit$data <- data
         fit$rnd <- rnd
         fit$fix <- fix
@@ -115,7 +117,8 @@ glmmLasso_MultLambdas <- function(fix, rnd, data,
         
         modList[[l]] <- fit
         Delta.start <- rbind(Delta.start, fit$Deltamatrix[fit$conv.step, ])
-        Q.start <- c(Q.start, fit$Q_long[[fit$conv.step + 1]])
+        Q.start[[l+1]] <- fit$Q_long[[fit$conv.step + 1]]
+        if(nrow(Q.start[[l+1]])==1) Q.start[[l+1]] <- c(Q.start[[l+1]])
         
         
         

--- a/data/soccer.rda
+++ b/data/soccer.rda
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3592caabe8dc07718e6547d23490c3b635912afb97757ef139fec6560ee485b4
-size 5183


### PR DESCRIPTION
Previously, there was an error about `nrow` if you tried to run a model with multiple random effects. For example, see mod2 below. 

```
soccer <- transform(soccer, teamf=factor(team), posf=factor(pos))


mod1 <- cv.glmmLasso(fix = points ~ transfer.spendings + ave.unfair.score + 
                       ball.possession + tackles, rnd = list(teamf=~1), data = soccer, 
                     family = gaussian(link = "identity"), kfold = 5, lambda.final = 'lambda.1se')

mod2 <- cv.glmmLasso(fix = points ~ transfer.spendings + ave.unfair.score + 
                       ball.possession + tackles, rnd = list(teamf=~1, posf=~1), data = soccer, 
                     family = gaussian(link = "identity"), kfold = 5, lambda.final = 'lambda.1se')
```