### PR TITLE
handle multiple random effects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,9 @@
 Package: cv.glmmLasso
 Title: Cross-validation for multi-level lasso 
 Version: 0.0.0.9000
-Authors@R: c(person('Pirapong', 'Jitngamplang', email = 'pira.package@gmail.com', role = c('cre')), person('Jared', 'Lander', email = 'package@jaredlander.com', role = c('aut')))
+Authors@R: c(person('Pirapong', 'Jitngamplang', email = 'pira.package@gmail.com', role = c('cre')), 
+    person('Jared', 'Lander', email = 'package@jaredlander.com', role = c('aut')),
+    person("Mollie","Brooks", role = "ctb", comment=c(ORCID="0000-0001-6963-8326") ))
 Description: This performs cross-validation for multi-level lasso using glmmLasso.
 Depends: R (>= 2.10)
 License: MIT + file LICENSE

--- a/R/glmmLasso_MultLambdas.r
+++ b/R/glmmLasso_MultLambdas.r
@@ -88,7 +88,9 @@ glmmLasso_MultLambdas <- function(fix, rnd, data,
     # builing the first Delta.start, transpose required to make dimension
     
     Delta.start <- first_fit$Deltamatrix[first_fit$conv.step, ] %>% t()
-    Q.start <- first_fit$Q_long[[first_fit$conv.step + 1]]
+    Q.start <- list()
+    Q.start[[1]] <- first_fit$Q_long[[first_fit$conv.step + 1]]
+    if(nrow(Q.start[[1]])==1) Q.start[[1]] <- c(Q.start[[1]])
     
     for (l in seq_along(lambdas))
     {
@@ -102,12 +104,12 @@ glmmLasso_MultLambdas <- function(fix, rnd, data,
                                     family = family,
                                     lambda = lambdas[l],
                                     control = list(start=Delta.start[l,],
-                                                   q_start=Q.start[l]),...)
+                                                   q_start=Q.start[[l]]),...)
         
         # storing model objects before storing to modList
         fit$lambda <- lambdas[l]
         fit$Delta.start <- Delta.start[l,]
-        fit$Q.start <- Q.start[l]
+        fit$Q.start <- Q.start[[l]]
         fit$data <- data
         fit$rnd <- rnd
         fit$fix <- fix
@@ -115,7 +117,8 @@ glmmLasso_MultLambdas <- function(fix, rnd, data,
         
         modList[[l]] <- fit
         Delta.start <- rbind(Delta.start, fit$Deltamatrix[fit$conv.step, ])
-        Q.start <- c(Q.start, fit$Q_long[[fit$conv.step + 1]])
+        Q.start[[l+1]] <- fit$Q_long[[fit$conv.step + 1]]
+        if(nrow(Q.start[[l+1]])==1) Q.start[[l+1]] <- c(Q.start[[l+1]])
         
         
         

--- a/data/soccer.rda
+++ b/data/soccer.rda
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ad0c0b0dde678c81f1d3389bcf47511ad921464c24a9493eb2a93737f8183b79
-size 5223

--- a/tests/testthat/test-MultipleLambdas.R
+++ b/tests/testthat/test-MultipleLambdas.R
@@ -1,5 +1,5 @@
 context("MultipleLambdas")
-
+data("soccer", package = "glmmLasso")
 
 mod_intercept_slope <- glmmLasso_MultLambdas(fix = points ~ transfer.spendings + ave.unfair.score + ball.possession + tackles + ave.attend + sold.out, 
                              rnd = list(team =~ 1),

--- a/tests/testthat/test-MultipleRE.R
+++ b/tests/testthat/test-MultipleRE.R
@@ -2,11 +2,11 @@ context("MultipleRandomEffects")
 data("soccer", package = "glmmLasso")
 soccer <- transform(soccer, teamf=factor(team), posf=factor(pos))
 
-lambdas=seq(50, 0, by=-5)
 
 mod2RE <- cv.glmmLasso(fix = points ~ transfer.spendings + ave.unfair.score + 
-                         ball.possession + tackles, rnd = list(teamf=~1, posf=~1), data = soccer, 
-                     family = gaussian(link = "identity"), kfold = 5, lambda.final = 'lambda.1se')
+                           ball.possession + tackles, rnd = list(teamf=~1, posf=~1), data = soccer, 
+                       family = gaussian(link = "identity"), kfold = 5, lambda.final = 'lambda.1se',
+                       lambdas=seq(50, 0, by=-5))
 
 test_that("Final model contains specified number of random effects", {
     expect_equal(length(mod2RE$glmmLasso.final$Q), 2)

--- a/tests/testthat/test-MultipleRE.R
+++ b/tests/testthat/test-MultipleRE.R
@@ -1,0 +1,13 @@
+context("MultipleRandomEffects")
+data("soccer", package = "glmmLasso")
+soccer <- transform(soccer, teamf=factor(team), posf=factor(pos))
+
+lambdas=seq(50, 0, by=-5)
+
+mod2RE <- cv.glmmLasso(fix = points ~ transfer.spendings + ave.unfair.score + 
+                         ball.possession + tackles, rnd = list(teamf=~1, posf=~1), data = soccer, 
+                     family = gaussian(link = "identity"), kfold = 5, lambda.final = 'lambda.1se')
+
+test_that("Final model contains specified number of random effects", {
+    expect_equal(length(mod2RE$glmmLasso.final$Q), 2)
+})


### PR DESCRIPTION
This is identical to my last pull request (#16). I restarted because I was trying to incorporate the latest commit (#15), but no matter what I've tried, I get errors when I try to download the latest version (see #17). 

This version of the code works for both models below, whereas the current version only works for `mod1`.
```
library(glmmLasso)
data("soccer")
library(cv.glmmLasso)
soccer <- transform(soccer, teamf=factor(team), posf=factor(pos))

mod1 <- cv.glmmLasso(fix = points ~ transfer.spendings + ave.unfair.score + 
                         ball.possession + tackles, rnd = list(teamf=~1), data = soccer, 
                     family = gaussian(link = "identity"), kfold = 5, lambda.final = 'lambda.1se')

mod2 <- cv.glmmLasso(fix = points ~ transfer.spendings + ave.unfair.score + 
                         ball.possession + tackles, rnd = list(teamf=~1, posf=~1), data = soccer, 
                     family = gaussian(link = "identity"), kfold = 5, lambda.final = 'lambda.1se')
```